### PR TITLE
Make sure target is a direct child

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -160,7 +160,7 @@ var initializeTabs = function (tabs) {
     var $content = $(this).parents('.tabbable').first()
       .find('.tab-content').first();
     var targetIdx = $(this).index();
-    var $target = $content.find('[data-idx=' + targetIdx + ']');
+    var $target = $content.find('> [data-idx=' + targetIdx + ']');
 
     e.preventDefault();
     activate($(this), $(this).parent());
@@ -1808,12 +1808,15 @@ formNode.prototype.clone = function (parentNode) {
   node.formElement = this.formElement;
   node.schemaElement = this.schemaElement;
   node.view = this.view;
-  node.children = _.map(this.children, function (child) {
-    return child.clone(node);
+
+  _.each(this.children, function(child) {
+    node.appendChild(child.clone());
   });
+
   if (this.childTemplate) {
     node.childTemplate = this.childTemplate.clone(node);
   }
+
   return node;
 };
 


### PR DESCRIPTION
Scenario:

Case you have a `selectFieldSet` within an `tabarray`, a weird behavior happens, where fields that should be active are deactivated and `selectFiledSet` rules are no longer respected.

This PR fix that by making sure that when we move from tab to tab the components within the tabs are not affected.

In case you want to reproduce this error, fire up the playground and generate a form with this schema:
```json
{
  "schema": {
    "text1": {
      "type": "string",
      "title": "text 1"
    },
    "text2": {
      "type": "string",
      "title": "Text 2"
    }
  },
  "form": [
    {
      "type": "tabarray",
      "items": {
        "type": "section",
        "items": [{
            "type": "selectfieldset",
            "title": "Make a choice",
            "items": [
              {
                "key": "text1",
                "legend": "Text 1"
              },
              {
                "key": "text2",
                "legend": "Text 2"
              }
            ]
          }
        ]
      }
    }
  ]
}
```